### PR TITLE
[codex] Add MiMo-V2.5-Pro TP8 runtime docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RTX 6000 Pro Wiki — Running Large LLMs on PCIe GPUs
 
-Community-sourced knowledge base for running large language models (Qwen3.5-397B, MiniMax M2.5, Kimi-K2.5, Kimi-K2.6, GLM-5) on NVIDIA RTX 6000 Pro (Blackwell, SM120) GPUs in 2×, 4×, and 8× PCIe configurations **without NVLink**.
+Community-sourced knowledge base for running large language models (Qwen3.5-397B, MiniMax M2.5, MiMo-V2.5-Pro, Kimi-K2.5, Kimi-K2.6, GLM-5) on NVIDIA RTX 6000 Pro (Blackwell, SM120) GPUs in 2×, 4×, and 8× PCIe configurations **without NVLink**.
 
 > Synthesized from ~5,000 [Discord](https://discord.gg/pYCvaQTf) messages, 300+ screenshots, and months of community experimentation.
 
@@ -13,6 +13,7 @@ Community-sourced knowledge base for running large language models (Qwen3.5-397B
 | [Qwen3.5-397B](models/qwen35-397b.md) | 397B MoE | 17B | 4× | 350 tok/s (8×, SGLang) | [→](models/qwen35-397b.md) |
 | [Qwen3.5-27B/122B](models/qwen35-27b.md) | 27B–122B | — | 1× | — | [→](models/qwen35-27b.md) |
 | [MiniMax M2.5](models/minimax-m25.md) | 229B MoE | — | 2× | 85-89 tok/s (NVFP4) | [→](models/minimax-m25.md) |
+| [MiMo-V2.5-Pro](models/mimo-v25-pro/README.md) | MoE | — | 8× | TP8 NVFP4/MXFP8 + MTP/EAGLE | [→](models/mimo-v25-pro/README.md) |
 | [Kimi-K2.5](models/kimi-k25.md) | 530B MoE | — | 8× | 101 tok/s (PCIe switch) | [→](models/kimi-k25.md) |
 | [Kimi-K2.6](models/kimi-k26.md) | MoE | — | 8× | Community image + MLA Eagle | [→](models/kimi-k26.md) |
 | [GLM-5](models/glm5.md) | 744B MoE | 40B | 8× | 105 tok/s (MTP) | [→](models/glm5.md) |

--- a/models/mimo-v25-pro/README.md
+++ b/models/mimo-v25-pro/README.md
@@ -1,0 +1,57 @@
+# MiMo-V2.5-Pro on RTX PRO 6000 Blackwell
+
+This directory records the TP=8 MiMo-V2.5-Pro NVFP4/MXFP8 bring-up on 8x RTX PRO 6000 Blackwell PCIe with SGLang and B12X.
+
+The validated artifact is a mixed ModelOpt checkpoint:
+
+- routed expert MLPs quantized to NVFP4
+- fused QKV attention tensors converted from the upstream TP-interleaved FP8 layout to MXFP8
+- BF16 MTP draft weights provided through a small serving overlay
+- serving target is SGLang + B12X with TP=8, MTP/EAGLE, B12X attention, B12X MoE, FP8 KV cache, and CUDA graph target verify
+
+## Current artifacts
+
+| Artifact | Value |
+|---|---|
+| Upstream source | `XiaomiMiMo/MiMo-V2.5-Pro` |
+| Public checkpoint | `festr2/MiMo-V2.5-Pro-NVFP4-MXFP8-attn-TP8` |
+| Runtime image | `voipmonitor/sglang:mimo-v25-pro-tp8-microrecip-20260510` |
+| Runtime digest | `sha256:b634da4afa79fb4bb8bb06c67938c8f3a816af96bb31d307605c2a56f35fa444` |
+| Base image | `docker.io/lukealonso/sglang-cuda13-b12x:w4a16` |
+| Target TP | `8` |
+| TP=16 status | not validated |
+
+## Documents
+
+| Page | Scope |
+|---|---|
+| [Quantization pipeline](quantization.md) | Exact BF16 dequantization, BF16 smoke, NVFP4 quantization, MTP fixup, MXFP8 QKV conversion, and final mixed checkpoint assembly. |
+| [SGLang/B12X patches](sglang-b12x-patches.md) | Runtime bugs found, patch files used, root-cause evidence, and why the final micro MoE reciprocal-scale path was needed. |
+| [Running the model](running.md) | DockerHub image, exact `docker run` command, health/log/smoke commands, and current runtime caveats. |
+
+## Validated runtime result
+
+The production-style SGLang instance on port `30004` was run with MTP/EAGLE enabled and `--cuda-graph-max-bs 8`.
+
+Smoke test:
+
+- prompt required the exact sentence `The capital of France is Paris.`
+- output included the exact required sentence
+- output then produced a coherent checkpoint-integrity paragraph
+- no CJK or replacement-token corruption was detected
+
+Concurrent soak:
+
+| Run | Result |
+|---|---|
+| first 8-way soak | 8/8 HTTP 200, 2,985 completion tokens, 83 s |
+| warm 8-way soak | 8/8 HTTP 200, 4,042 completion tokens, 31 s |
+
+The warm soak had no CJK characters, Unicode replacement characters, or multi-character non-ASCII corruption runs. One local checker warning was only a normal ASCII separator line in a generated incident-report heading.
+
+## Important caveats
+
+- TP=8 is the validated target. TP=16 may be possible at the SGLang partitioning layer, but the source MiMo Pro fused QKV tensors were TP-packed for TP=8 and TP=16 has not been proven.
+- MiMo's tokenizer defaults to thinking mode. For normal chat smoke tests, pass `chat_template_kwargs: {"enable_thinking": false}`.
+- The current runtime image preserves the compiled BF16 linear path after warmup with `SGLANG_DISABLE_AUTOTUNED_LINEAR_AFTER_WARMUP=0`. This was needed for graph/eager consistency during MTP target-verify debugging, but it can cause Torch Inductor autotune for new large prefill shapes. Treat that as a known runtime performance issue, not a checkpoint-quality issue.
+- Earlier no-graph and no-MTP runs were useful gates, but the current validated image is the micro-MoE reciprocal-scale runtime described in this directory.

--- a/models/mimo-v25-pro/quantization.md
+++ b/models/mimo-v25-pro/quantization.md
@@ -1,0 +1,298 @@
+# MiMo-V2.5-Pro TP=8 quantization pipeline
+
+Date: 2026-05-10
+
+This page records the exact MiMo-V2.5-Pro TP=8 quantization path used to produce the public NVFP4/MXFP8 checkpoint.
+
+## Source checkpoint and TP layout
+
+Source model:
+
+```text
+XiaomiMiMo/MiMo-V2.5-Pro
+```
+
+Local source snapshot used during the run:
+
+```text
+/root/.cache/huggingface/hub/models--XiaomiMiMo--MiMo-V2.5-Pro/snapshots/a75207db63de3c320950fe6fcfa9ff60f341b7a2
+```
+
+The upstream Pro fused QKV tensors are TP-packed with TP=8. This is the critical detail that differs from older MiMo 2.5 scripts that defaulted to TP=4.
+
+Evidence from the shape check:
+
+| Item | Value |
+|---|---|
+| Tensor | `model.layers.0.self_attn.qkv_proj.weight` |
+| Weight shape | `[27136, 6144]` |
+| FP8 scale shape | `[216, 48]` |
+| TP=8 expected scale rows | `216` |
+| TP=4 expected scale rows | `212` |
+| TP=16 expected scale rows | `224` |
+
+Conclusion: every Pro dequantize/deinterleave command must use:
+
+```bash
+--mimo-qkv-tp-size 8
+```
+
+## 1. Dequantize upstream FP8 to BF16
+
+Wrapper:
+
+```bash
+scripts/dequantize_mimo_v25_pro.sh
+```
+
+Important defaults in the wrapper:
+
+```bash
+MODEL_ID=XiaomiMiMo/MiMo-V2.5-Pro
+OUTPUT_DIR=/data/models/MiMo-V2.5-Pro-BF16-qkv-deinterleaved
+WORKERS=8
+OUTPUT_SHARD_SIZE_GIB=8
+MIMO_QKV_TP_SIZE=8
+```
+
+Expanded command:
+
+```bash
+python3 tools/dequantize_fp8.py XiaomiMiMo/MiMo-V2.5-Pro \
+  --output-dir /data/models/MiMo-V2.5-Pro-BF16-qkv-deinterleaved \
+  --workers 8 \
+  --output-shard-size-gib 8 \
+  --mimo-deinterleave-qkv \
+  --mimo-qkv-tp-size 8
+```
+
+Result:
+
+- output: `/data/models/MiMo-V2.5-Pro-BF16-qkv-deinterleaved`
+- output size: about 1.9 TB
+- safetensors index present
+- total files processed: 34
+- total FP8 weights dequantized: 79,573
+- total weights: 80,008
+
+## 2. BF16 smoke validation
+
+The useful BF16 gate was a 256-token test with enough input-token budget. An earlier one-token test only proved loading, and an earlier 256-token run with `--max-input-tokens 128` was invalid because the MiMo chat template was truncated.
+
+Valid smoke command:
+
+```bash
+PYTHONUNBUFFERED=1 CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15 \
+.venv/bin/python tools/mimo_forward_smoke.py \
+  'What is the capital of France?' \
+  --model mimo_v25_pro \
+  --model-id /data/models/MiMo-V2.5-Pro-BF16-qkv-deinterleaved \
+  --streaming \
+  --gpu-capacity 90GiB \
+  --cpu-capacity 1090GiB \
+  --max-input-tokens 512 \
+  --max-new-tokens 256 \
+  --decode-mode kv-cache \
+  --disable-thinking
+```
+
+Observed answer:
+
+```text
+The capital of France is **Paris**
+```
+
+This is the valid BF16 coherence gate.
+
+## 3. Quantize routed experts to NVFP4
+
+Base NVFP4 output:
+
+```text
+/data/models/MiMo-V2.5-Pro-NVFP4
+```
+
+Main command:
+
+```bash
+PYTHONUNBUFFERED=1 \
+GPU_CAPACITY=84GiB \
+AMAX_CHECKPOINT_INTERVAL=8 \
+CLEANUP_INTERVAL=8 \
+RESUME_AMAX=/data/models/MiMo-V2.5-Pro-NVFP4/amax_checkpoint.safetensors \
+RESUME_BATCH=32 \
+scripts/quantize_mimo_v25_pro.sh
+```
+
+Expanded command:
+
+```bash
+python3 quantize.py \
+  --model mimo_v25_pro \
+  --model-id /data/models/MiMo-V2.5-Pro-BF16-qkv-deinterleaved \
+  --export-dir /data/models/MiMo-V2.5-Pro-NVFP4 \
+  --calib-config configs/calib_mimo_v25_pro.toml \
+  --save-amax /data/models/MiMo-V2.5-Pro-NVFP4/amax.safetensors \
+  --batch-tokens 16384 \
+  --streaming \
+  --cpu-capacity 1090GiB \
+  --gpu-capacity 84GiB \
+  --amax-checkpoint-interval 8 \
+  --cleanup-interval 8 \
+  --floor-amaxes \
+  --resume-amax /data/models/MiMo-V2.5-Pro-NVFP4/amax_checkpoint.safetensors \
+  --resume-batch 32
+```
+
+Calibration config:
+
+| Dataset | Batch size | Max length | Limit |
+|---|---:|---:|---:|
+| `text/agentic_coding_calib_v3.jsonl` | 16 | 1024 | 2048 |
+| `text/diverse_calib.jsonl` | 16 | 1024 | 512 |
+| `text/deep_calib.jsonl` | 1 | 4096 | 128 |
+
+Total calibration plan: 288 batches.
+
+Runtime changes during quantization:
+
+- increased streaming `GPU_CAPACITY` from `70GiB` to `84GiB`
+- increased amax checkpoint interval to 8
+- increased cleanup interval to 8
+- did not reduce calibration data, tensor formats, or quantization settings
+
+Quantization completed and exported:
+
+```text
+/data/models/MiMo-V2.5-Pro-NVFP4
+```
+
+## 4. MTP fixup
+
+The generic export emitted:
+
+```text
+No source index found, skipping MTP merge.
+```
+
+That was not enough for MiMo Pro serving with MTP/EAGLE. The separate fixup script was run:
+
+```bash
+scripts/fixup_mimo_v25_pro_nvfp4.sh
+```
+
+Expanded command:
+
+```bash
+python3 tools/fixup_mimo_nvfp4_export.py \
+  --source-dir /data/models/MiMo-V2.5-Pro-BF16-qkv-deinterleaved \
+  --export-dir /data/models/MiMo-V2.5-Pro-NVFP4
+```
+
+This copies draft-only MTP tensors into `model-mtp.safetensors` and updates the index. SGLang target-model loading later logs that these draft-only MTP weights are skipped by the target runner and loaded by the draft model runner, which is expected.
+
+## 5. Convert MiMo fused QKV attention FP8 to MXFP8
+
+Luke's correction was that the attention path should be TP-interleaved FP8 to MXFP8. The older `FP8_PB_WO` chimera was not the final path.
+
+Wrapper:
+
+```bash
+env MODEL_DIR=/root/.cache/huggingface/hub/models--XiaomiMiMo--MiMo-V2.5-Pro/snapshots/a75207db63de3c320950fe6fcfa9ff60f341b7a2 \
+  MIMO_QKV_TP_SIZE=8 \
+  OUTPUT_FORMAT=mxfp8 \
+  ON_INEXACT=requantize \
+  OUTPUT_DIR=/data/models/MiMo-V2.5-Pro-MXFP8-qkv-deinterleaved \
+  scripts/deinterleave_mimo_v25_pro_fp8_attn.sh
+```
+
+Expanded command:
+
+```bash
+python3 tools/deinterleave_mimo_fp8_qkv.py XiaomiMiMo/MiMo-V2.5-Pro \
+  --model-dir /root/.cache/huggingface/hub/models--XiaomiMiMo--MiMo-V2.5-Pro/snapshots/a75207db63de3c320950fe6fcfa9ff60f341b7a2 \
+  --output-dir /data/models/MiMo-V2.5-Pro-MXFP8-qkv-deinterleaved \
+  --mimo-qkv-tp-size 8 \
+  --output-format mxfp8 \
+  --on-inexact requantize \
+  --unchanged-shards symlink \
+  --force
+```
+
+Output:
+
+```text
+/data/models/MiMo-V2.5-Pro-MXFP8-qkv-deinterleaved
+```
+
+## 6. Build the mixed NVFP4/MXFP8 checkpoint
+
+Wrapper:
+
+```bash
+env BASE=/data/models/MiMo-V2.5-Pro-NVFP4 \
+  FP8_ATTN=/data/models/MiMo-V2.5-Pro-MXFP8-qkv-deinterleaved \
+  OUTPUT=/data/models/MiMo-V2.5-Pro-NVFP4-MXFP8-attn \
+  scripts/build_mimo_v25_pro_chimera.sh
+```
+
+Expanded commands:
+
+```bash
+python3 tools/build_mimo_nvfp4_fp8_attn_chimera.py \
+  --base /data/models/MiMo-V2.5-Pro-NVFP4 \
+  --fp8-attn /data/models/MiMo-V2.5-Pro-MXFP8-qkv-deinterleaved \
+  --output /data/models/MiMo-V2.5-Pro-NVFP4-MXFP8-attn \
+  --attention-format mxfp8 \
+  --unchanged-shards symlink \
+  --force
+
+python3 tools/write_mimo_chimera_mixed_quant_config.py \
+  /data/models/MiMo-V2.5-Pro-NVFP4-MXFP8-attn
+```
+
+Post-process summary:
+
+- main QKV tensors replaced: 70
+- MTP QKV tensors replaced: 3
+- total QKV replacements: 73
+- `FP8_PB_WO` QKV modules: 0
+- MXFP8 QKV modules: 73
+- total `quantized_layers` entries: 79,561
+
+Final target checkpoint:
+
+```text
+/data/models/MiMo-V2.5-Pro-NVFP4-MXFP8-attn
+```
+
+MTP serving overlay:
+
+```text
+/data/models/MiMo-V2.5-Pro-NVFP4-MXFP8-attn-BF16-MTP
+```
+
+The overlay includes BF16 MTP draft weights and symlinks the target-model shards/configs back to the mixed checkpoint.
+
+## Size and upload
+
+Symlink-dereferenced sizes:
+
+| Path | Bytes | GiB |
+|---|---:|---:|
+| `/data/models/MiMo-V2.5-Pro-NVFP4-MXFP8-attn` | 596,967,489,918 | 555.969 |
+| `/data/models/MiMo-V2.5-Pro-NVFP4-MXFP8-attn-BF16-MTP` | 597,452,029,130 | 556.421 |
+
+The smaller apparent local footprint is due to shard symlinks back into the base NVFP4 export.
+
+Public Hugging Face upload:
+
+```text
+festr2/MiMo-V2.5-Pro-NVFP4-MXFP8-attn-TP8
+```
+
+Upload completed at:
+
+```text
+2026-05-09T23:12:22.711028+00:00
+```

--- a/models/mimo-v25-pro/running.md
+++ b/models/mimo-v25-pro/running.md
@@ -1,0 +1,181 @@
+# Running MiMo-V2.5-Pro TP=8 on SGLang/B12X
+
+This is the exact runbook for the validated MiMo-V2.5-Pro TP=8 runtime.
+
+## Image
+
+Use the DockerHub image with the SGLang/B12X patch overlay baked in:
+
+```bash
+voipmonitor/sglang:mimo-v25-pro-tp8-microrecip-20260510
+```
+
+Digest:
+
+```text
+sha256:b634da4afa79fb4bb8bb06c67938c8f3a816af96bb31d307605c2a56f35fa444
+```
+
+The `mimo-v25-pro-tp8-microrecip-latest` tag points to the same digest at the time this page was written, but the dated tag is preferred for reproducibility.
+
+## Required model directories
+
+The command below assumes these paths exist on the host:
+
+```text
+/data/models/MiMo-V2.5-Pro-NVFP4-MXFP8-attn-BF16-MTP
+/data/models/MiMo-V2.5-Pro-NVFP4-MXFP8-attn
+/data/models/MiMo-V2.5-Pro-NVFP4
+/models/.cache/huggingface
+/models/.vllm_cache/triton
+/models/.vllm_cache/sglang-generated
+```
+
+The public checkpoint is:
+
+```text
+festr2/MiMo-V2.5-Pro-NVFP4-MXFP8-attn-TP8
+```
+
+The MTP overlay directory is expected to contain the BF16 draft weights and symlink the target-model files back to the mixed NVFP4/MXFP8 checkpoint.
+
+## Launch command
+
+This command runs TP=8 on GPUs 0-7 and serves the OpenAI-compatible API on port `30004`.
+
+```bash
+docker run -d --name mimo-v25-pro-tp8-mtp-30004 \
+  --gpus '"device=0,1,2,3,4,5,6,7"' \
+  --ipc=host --network host --shm-size=32g \
+  --ulimit memlock=-1 --ulimit stack=67108864 \
+  -e SAFETENSORS_FAST_GPU=1 \
+  -e CUTE_DSL_ARCH="sm_120a" \
+  -e SGLANG_PREVENT_THOUGHT_LOOPS=1 \
+  -e B12X_MOE_FORCE_A16=0 \
+  -e B12X_ENABLE_DYNAMIC_DOWN_SCALE=0 \
+  -e B12X_MOE_EAGER_EXACT_DYNAMIC=0 \
+  -e SGLANG_DISABLE_AUTOTUNED_LINEAR_AFTER_WARMUP=0 \
+  -e PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
+  -e NCCL_P2P_LEVEL=SYS \
+  -e NCCL_IB_DISABLE=1 \
+  -e NCCL_ALLOC_P2P_NET_LL_BUFFERS=1 \
+  -e NCCL_MIN_NCHANNELS=8 \
+  -e NCCL_CUMEM_HOST_ENABLE=0 \
+  -e NCCL_NET_GDR_LEVEL=SYS \
+  -v /data/models/MiMo-V2.5-Pro-NVFP4-MXFP8-attn-BF16-MTP:/data/models/MiMo-V2.5-Pro-NVFP4-MXFP8-attn-BF16-MTP:ro \
+  -v /data/models/MiMo-V2.5-Pro-NVFP4-MXFP8-attn:/data/models/MiMo-V2.5-Pro-NVFP4-MXFP8-attn:ro \
+  -v /data/models/MiMo-V2.5-Pro-NVFP4:/data/models/MiMo-V2.5-Pro-NVFP4:ro \
+  -v /models/.cache/huggingface:/root/.cache/huggingface \
+  -v /models/.vllm_cache/triton:/root/.triton \
+  -v /models/.vllm_cache/sglang-generated:/root/.cache/sglang-generated \
+  voipmonitor/sglang:mimo-v25-pro-tp8-microrecip-20260510 \
+  python3 -m sglang.launch_server \
+    --model-path /data/models/MiMo-V2.5-Pro-NVFP4-MXFP8-attn-BF16-MTP \
+    --tokenizer-path /data/models/MiMo-V2.5-Pro-NVFP4-MXFP8-attn \
+    --served-model-name mimo-v2.5-pro \
+    --tp-size 8 \
+    --json-model-override-args '{"architectures":["MiMoV2FlashForCausalLM"]}' \
+    --page-size 64 \
+    --host 0.0.0.0 \
+    --port 30004 \
+    --kv-cache-dtype fp8_e4m3 \
+    --quantization modelopt_mixed \
+    --mem-fraction-static 0.85 \
+    --swa-full-tokens-ratio 0.3 \
+    --chunked-prefill-size 8192 \
+    --context-length 131072 \
+    --max-running-requests 8 \
+    --enable-multi-layer-eagle \
+    --reasoning-parser mimo \
+    --tool-call-parser mimo \
+    --speculative-algorithm EAGLE \
+    --speculative-num-steps 3 \
+    --speculative-eagle-topk 1 \
+    --speculative-num-draft-tokens 4 \
+    --moe-runner-backend b12x \
+    --attention-backend b12x \
+    --mm-attention-backend b12x \
+    --fp4-gemm-backend cutlass \
+    --fp8-gemm-backend flashinfer_cutlass \
+    --sampling-backend pytorch \
+    --cuda-graph-max-bs 8 \
+    --disable-piecewise-cuda-graph \
+    --enable-metrics
+```
+
+## Health and logs
+
+Health:
+
+```bash
+curl -sS http://127.0.0.1:30004/health
+```
+
+Follow logs:
+
+```bash
+docker logs -f mimo-v25-pro-tp8-mtp-30004
+```
+
+Last 200 lines:
+
+```bash
+docker logs --tail 200 mimo-v25-pro-tp8-mtp-30004
+```
+
+Recent hard errors:
+
+```bash
+docker logs --since 10m mimo-v25-pro-tp8-mtp-30004 2>&1 \
+  | rg -i 'traceback|device-side|scheduler hit|cuda error|exception|nan|\binf\b'
+```
+
+## Smoke test
+
+MiMo's tokenizer defaults to thinking mode. For normal chat tests, pass:
+
+```json
+"chat_template_kwargs": {"enable_thinking": false}
+```
+
+Smoke request:
+
+```bash
+curl -sS http://127.0.0.1:30004/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"mimo-v2.5-pro","messages":[{"role":"user","content":"First write exactly this sentence: The capital of France is Paris. Then write one coherent paragraph explaining why checkpoint integrity matters for large language model deployment."}],"temperature":0,"max_tokens":384,"chat_template_kwargs":{"enable_thinking":false}}'
+```
+
+Expected properties:
+
+- HTTP 200
+- output includes `The capital of France is Paris.`
+- no CJK or replacement-character corruption
+- `finish_reason` should normally be `stop`
+
+## Runtime notes
+
+`--page-size 64` is mandatory for B12X attention.
+
+`--fp4-gemm-backend cutlass` was used in the validated image. Earlier runs with other FP4 paths were useful for isolation, but this is the current documented runtime.
+
+`--disable-piecewise-cuda-graph` is intentional. The validated path uses normal CUDA graph target verify with `--cuda-graph-max-bs 8`; piecewise CUDA graph was disabled after earlier runtime recapture failures.
+
+`SGLANG_DISABLE_AUTOTUNED_LINEAR_AFTER_WARMUP=0` is intentional for graph/eager consistency, but it can produce Torch Inductor `AUTOTUNE mm(...)` output during novel large prefill shapes. If this appears during inference, it is usually dynamic BF16 dense-linear compilation for a new prefill shape, not B12X MoE or checkpoint corruption.
+
+## Validated result
+
+The production-style container tested before publishing this page was:
+
+```text
+mimo-v25-pro-tp8-mtp-prod-microrecip-30004
+```
+
+Results:
+
+| Test | Result |
+|---|---|
+| smoke | coherent Paris + checkpoint-integrity answer, HTTP 200 |
+| first 8-way concurrent soak | 8/8 HTTP 200, 2,985 completion tokens, 83 s |
+| warm 8-way concurrent soak | 8/8 HTTP 200, 4,042 completion tokens, 31 s |
+| health after soak | HTTP 200 |

--- a/models/mimo-v25-pro/sglang-b12x-patches.md
+++ b/models/mimo-v25-pro/sglang-b12x-patches.md
@@ -1,0 +1,209 @@
+# SGLang and B12X changes for MiMo-V2.5-Pro
+
+Date: 2026-05-10
+
+This page records the runtime changes needed to make the TP=8 MiMo-V2.5-Pro NVFP4/MXFP8 checkpoint run coherently with SGLang, B12X, MTP/EAGLE, and CUDA graph target verify.
+
+## Runtime baseline
+
+Base image:
+
+```text
+docker.io/lukealonso/sglang-cuda13-b12x:w4a16
+```
+
+The validated image with patches baked in:
+
+```text
+voipmonitor/sglang:mimo-v25-pro-tp8-microrecip-20260510
+sha256:b634da4afa79fb4bb8bb06c67938c8f3a816af96bb31d307605c2a56f35fa444
+```
+
+The image is not a generic upstream SGLang image. It contains targeted SGLang and B12X overlays listed below.
+
+## Patch inventory
+
+| File in image | Why it was changed |
+|---|---|
+| `/opt/sglang/python/sglang/srt/models/mimo_v2.py` | MiMo-V2.5-Pro architecture handling, MTP target/draft loading behavior, and debug instrumentation for layer/MoE state comparisons. |
+| `/opt/sglang/python/sglang/srt/speculative/multi_layer_eagle_worker.py` | MTP/EAGLE runtime adjustments used by the MiMo serving path. |
+| `/opt/sglang/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py` | Target-verify graph/eager comparison instrumentation and ordering controls used to isolate corruption. |
+| `/opt/sglang/python/sglang/srt/model_executor/cuda_graph_runner.py` | CUDA graph replay fixes, including restaging MiMo hybrid/SWA cache locations for target verify. |
+| `/opt/sglang/python/sglang/srt/layers/attention/b12x_backend.py` | B12X attention metadata/workspace alignment for graph replay versus eager decode. |
+| `/opt/sglang/python/sglang/srt/layers/quantization/unquant.py` | BF16 unquantized linear path stabilization for graph/eager consistency. |
+| `/opt/sglang/python/sglang/srt/layers/quantization/modelopt_quant.py` | ModelOpt mixed NVFP4/MXFP8 loading, B12X MoE output-buffer handling, and split-topk proof-of-cause hooks. |
+| `/opt/sglang/python/sglang/srt/layers/communicator.py` | Debug context propagation through communicator/allreduce boundaries. |
+| `/opt/sglang/python/sglang/srt/layers/layernorm.py` | Native RMSNorm isolation switch used during graph/eager debugging. |
+| `/opt/sglang/python/sglang/srt/layers/sampler.py` | PyTorch sampler path used to avoid the earlier sampling corruption path. |
+| `/opt/sglang/python/sglang/srt/entrypoints/openai/serving_chat.py` | MiMo chat/serving behavior used by the OpenAI-compatible endpoint. |
+| `/opt/venv/lib/python3.12/site-packages/b12x/integration/tp_moe.py` | B12X MoE integration instrumentation and deterministic split-topk proof-of-cause path. |
+| `/opt/venv/lib/python3.12/site-packages/b12x/moe/fused/micro.py` | Production fix candidate: allow the direct micro MoE kernel with reciprocal scales and invert scales inside the kernel. |
+
+## Required runtime settings
+
+These settings were part of the validated runtime:
+
+| Setting | Value |
+|---|---|
+| `--tp-size` | `8` |
+| `--json-model-override-args` | `{"architectures":["MiMoV2FlashForCausalLM"]}` |
+| `--page-size` | `64` |
+| `--quantization` | `modelopt_mixed` |
+| `--kv-cache-dtype` | `fp8_e4m3` |
+| `--attention-backend` | `b12x` |
+| `--moe-runner-backend` | `b12x` |
+| `--fp4-gemm-backend` | `cutlass` |
+| `--fp8-gemm-backend` | `flashinfer_cutlass` |
+| `--sampling-backend` | `pytorch` |
+| `--enable-multi-layer-eagle` | enabled |
+| `--speculative-algorithm` | `EAGLE` |
+| `--speculative-num-steps` | `3` |
+| `--speculative-eagle-topk` | `1` |
+| `--speculative-num-draft-tokens` | `4` |
+| `--cuda-graph-max-bs` | `8` |
+| `--disable-piecewise-cuda-graph` | enabled |
+
+B12X attention requires `--page-size 64`. With page size 1, startup fails with:
+
+```text
+ValueError: b12x attention backend requires page_size=64, got 1
+```
+
+## Debugging timeline
+
+### 1. Checkpoint correctness came first
+
+The BF16 checkpoint was validated before quantization with `tools/mimo_forward_smoke.py` for at least 256 generated tokens. The corrected BF16 smoke answered:
+
+```text
+The capital of France is **Paris**
+```
+
+The final NVFP4/MXFP8 checkpoint was then validated without MTP/EAGLE and with CUDA graph modes disabled before target-verify graph work continued.
+
+### 2. Sampling corruption was isolated
+
+Early long generations could start coherently and later degrade into multilingual or garbled text. BF16 KV cache did not explain it. Switching to the PyTorch sampler path made greedy and controlled sampled tests coherent under the validated configuration.
+
+Current runtime uses:
+
+```bash
+--sampling-backend pytorch
+```
+
+### 3. BF16 dense linear graph/eager mismatch
+
+MiMo has unquantized BF16 dense paths in addition to the routed FP4 MoE paths. During CUDA graph capture, SGLang used a compiled/autotuned BF16 linear path. After warmup, eager target-verify could fall back to `F.linear`, meaning graph replay and eager comparison were not executing the same BF16 linear implementation.
+
+The runtime therefore sets:
+
+```bash
+SGLANG_DISABLE_AUTOTUNED_LINEAR_AFTER_WARMUP=0
+```
+
+This keeps the method stable across graph capture/replay/eager. The downside is that new large dynamic prefill shapes can trigger Torch Inductor autotune during inference. That is a performance caveat, not a checkpoint-integrity failure.
+
+### 4. B12X attention graph metadata alignment
+
+The target-verify compare originally showed graph/eager B12X attention metadata mismatches. The B12X attention overlay aligns graph-capture workspace metadata with the eager decode path, including KV chunk sizing and workspace capacity for the dense eager-aligned replay plan.
+
+This is why the runtime image includes:
+
+```text
+/opt/sglang/python/sglang/srt/layers/attention/b12x_backend.py
+```
+
+### 5. SWA cache-location replay fix
+
+In MiMo hybrid/sliding-window attention, graph replay must restage both full KV and SWA KV cache locations. The SGLang CUDA graph runner patch restages the SWA output cache locations used by the target-verify graph.
+
+This is why the runtime image includes:
+
+```text
+/opt/sglang/python/sglang/srt/model_executor/cuda_graph_runner.py
+```
+
+### 6. B12X NVFP4 MoE accumulation mismatch
+
+After attention metadata and cache-location issues were addressed, graph/eager differences remained in the B12X FP4 MoE expert-output path.
+
+Evidence:
+
+- router inputs matched
+- router logits matched
+- top-k ids matched
+- top-k weights matched
+- first nonzero difference appeared at MoE expert output before TP allreduce
+- forcing `B12X_MOE_FORCE_A16=1` made graph/eager exact
+- SGLang-side split-topk made graph/eager exact
+- B12X-side split-topk made graph/eager exact
+
+The B12X static/dynamic FP4 MoE path scatters routed expert outputs using BF16 atomic add. Multiple top-k expert contributions can therefore be order-dependent between graph replay and eager execution.
+
+### 7. Preferred fix: B12X direct micro MoE with reciprocal scales
+
+B12X already had a direct micro MoE kernel for small shapes such as target-verify/decode batches. That kernel accumulates top-k contributions deterministically inside one kernel instead of using the static/dynamic BF16 atomic scatter path.
+
+It was not selected for this checkpoint because the micro-kernel support check rejected:
+
+```text
+input_scales_are_reciprocal=True
+```
+
+SGLang's ModelOpt NVFP4 call uses reciprocal input scales, so the B12X micro MoE patch:
+
+- allows the micro kernel when `input_scales_are_reciprocal=True`
+- inverts the relevant input/down scales inside the micro kernel
+- keeps A16 off
+- avoids the split-topk multi-launch fallback
+
+The important patched file is:
+
+```text
+/opt/venv/lib/python3.12/site-packages/b12x/moe/fused/micro.py
+```
+
+With the micro reciprocal-scale patch only, target-verify graph/eager compare became exact:
+
+| Compare | Result |
+|---|---|
+| logits | `max_abs=0.0`, `mean_abs=0.0`, `top_mismatch=0/4` |
+| hidden | `max_abs=0.0` |
+| layer stats/residual/hidden | `all_match max_abs=0.0` |
+
+## Validated production-style result
+
+The patched production-style container was run on port `30004` with:
+
+- TP=8
+- MTP/EAGLE enabled
+- target CUDA graphs enabled for `bs=[1..8]`
+- piecewise CUDA graph disabled
+- A16 MoE disabled
+- no graph/eager debug compare env
+- no split-topk env
+
+Smoke:
+
+- HTTP 200
+- exact sentence `The capital of France is Paris.`
+- coherent checkpoint-integrity paragraph
+- no CJK/replacement-token corruption
+
+Warm 8-way soak:
+
+- 8/8 requests returned HTTP 200
+- 4,042 completion tokens
+- 6,304 total tokens
+- 31 s wall time
+- health remained HTTP 200
+
+## What not to confuse with real failures
+
+During startup and new dynamic-shape prefill, Torch Inductor may log lines like:
+
+```text
+No valid triton configs. OutOfMemoryError: out of resource
+```
+
+These are rejected autotune candidates, not necessarily fatal GPU OOMs. A real failure should be correlated with process exit, traceback, CUDA device-side assert, NaN/Inf detection, scheduler shutdown, or `/health` failure.


### PR DESCRIPTION
## Summary

Adds a dedicated `models/mimo-v25-pro/` documentation section for the MiMo-V2.5-Pro TP=8 NVFP4/MXFP8 bring-up.

Included pages:

- `README.md`: overview, artifacts, validation summary, caveats
- `quantization.md`: exact BF16 dequantization, smoke validation, NVFP4 quantization, MTP fixup, MXFP8 QKV conversion, and final checkpoint assembly
- `sglang-b12x-patches.md`: exact SGLang/B12X runtime patches, root-cause isolation, and why the B12X micro MoE reciprocal-scale path is needed
- `running.md`: Docker image, exact launch command, health/log/smoke commands, and runtime notes

Also adds MiMo-V2.5-Pro to the root README model table.

## Validation

- Ran `git diff --check` before staging.
- Documentation content was sourced from the local MiMo-V2.5-Pro quantization and runtime reports in `/root/mimo/quant-toolkit/reports/`.
- No code or runtime behavior changed.
